### PR TITLE
Correction of two typos

### DIFF
--- a/cityjson-spec/1.1/extension/quality.schema.json
+++ b/cityjson-spec/1.1/extension/quality.schema.json
@@ -168,7 +168,7 @@
           "type": "object",
           "properties": {
             "value": {
-              "#ref": "definitions/#uom-pq-variance-matrix"
+              "$ref": "definitions/#uom-pq-variance-matrix"
             },
             "uom": {
               "enum": [
@@ -184,7 +184,7 @@
           ]
         },
         {
-          "#ref": "definitions/#pq-variance-matrix"
+          "$ref": "definitions/#pq-variance-matrix"
         }
       ]
     },

--- a/cityjson-spec/1.1/extension/quality.schema.json
+++ b/cityjson-spec/1.1/extension/quality.schema.json
@@ -168,7 +168,7 @@
           "type": "object",
           "properties": {
             "value": {
-              "$ref": "definitions/#uom-pq-variance-matrix"
+              "$ref": "#/definitions/uom-pq-variance-matrix"
             },
             "uom": {
               "enum": [
@@ -184,7 +184,7 @@
           ]
         },
         {
-          "$ref": "definitions/#pq-variance-matrix"
+          "$ref": "#/definitions/pq-variance-matrix"
         }
       ]
     },


### PR DESCRIPTION
There was  two "#ref" in the extension. Here is a hot fix to "$ref"